### PR TITLE
Remove pre-commit as an installed dev dependency

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2.7.3
       - name: Install Poetry
-        run: pipx install poetry
+        run: pipx install poetry pre-commit
       - name: Configure poetry
         run: |
           poetry config virtualenvs.create true

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -192,7 +192,7 @@ jobs:
         working-directory: ${{ env.WORKING_DIR }}
         run: |
           python -m pip install -U pip
-          python -m pip install -U pre-commit
+          pipx install pre-commit
           python -m pip install -r requirements-dev.txt
           python -m pip install -e .
           maturin build --out dist
@@ -229,7 +229,7 @@ jobs:
         working-directory: ${{ env.WORKING_DIR }}
         run: |
           python -m pip install -U pip
-          python -m pip install -U pre-commit
+          pipx install pre-commit
           python -m pip install -r requirements-dev.txt
       - name: MyPy
         working-directory: ${{ env.WORKING_DIR }}
@@ -264,7 +264,7 @@ jobs:
         working-directory: ${{ env.WORKING_DIR }}
         run: |
           python -m pip install -U pip
-          python -m pip install -U pre-commit
+          pipx install pre-commit
           python -m pip install -r requirements-dev.txt
       - name: Pre-commit install
         working-directory: ${{ env.WORKING_DIR }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,7 +3,7 @@ name: Testing
 on:
   push:
     branches:
-    - main
+      - main
   pull_request:
 env:
   CARGO_TERM_COLOR: always
@@ -16,38 +16,38 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Install Rust
-      run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-    - name: Cache dependencies
-      uses: Swatinem/rust-cache@v2.7.3
-    - name: Run cargo clippy
-      run: cargo clippy --all-targets -- --deny warnings
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2.7.3
+      - name: Run cargo clippy
+        run: cargo clippy --all-targets -- --deny warnings
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Install Rust
-      run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-    - name: Cache dependencies
-      uses: Swatinem/rust-cache@v2.7.3
-    - name: Run cargo fmt
-      run: cargo fmt --all -- --check
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2.7.3
+      - name: Run cargo fmt
+        run: cargo fmt --all -- --check
   test:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Install Rust
-      run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-    - name: Cache dependencies
-      uses: Swatinem/rust-cache@v2.7.3
-    - name: Run cargo test
-      run: cargo test --locked
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2.7.3
+      - name: Run cargo test
+        run: cargo test --locked
   poetry-linting:
     strategy:
       fail-fast: false
@@ -55,36 +55,36 @@ jobs:
         project_type: ["application", "lib"]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Install Rust
-      run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-    - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@v2.7.3
-    - name: Install Poetry
-      run: pipx install poetry
-    - name: Configure poetry
-      run: |
-        poetry config virtualenvs.create true
-        poetry config virtualenvs.in-project true
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "${{ env.MIN_PYTHON_VERSION }}"
-    - name: Build package
-      run: cargo build --release
-    - name: Run creation
-      run: |
-        ./scripts/ci_run.sh ${{ matrix.project_type }} 1
-    - name: Install Dependencies
-      working-directory: ${{ env.WORKING_DIR }}
-      run: poetry install
-    - name: MyPy
-      working-directory: ${{ env.WORKING_DIR }}
-      run: poetry run mypy .
-    - name: ruff
-      working-directory: ${{ env.WORKING_DIR }}
-      run: poetry run ruff check .
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2.7.3
+      - name: Install Poetry
+        run: pipx install poetry
+      - name: Configure poetry
+        run: |
+          poetry config virtualenvs.create true
+          poetry config virtualenvs.in-project true
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "${{ env.MIN_PYTHON_VERSION }}"
+      - name: Build package
+        run: cargo build --release
+      - name: Run creation
+        run: |
+          ./scripts/ci_run.sh ${{ matrix.project_type }} 1
+      - name: Install Dependencies
+        working-directory: ${{ env.WORKING_DIR }}
+        run: poetry install
+      - name: MyPy
+        working-directory: ${{ env.WORKING_DIR }}
+        run: poetry run mypy .
+      - name: ruff
+        working-directory: ${{ env.WORKING_DIR }}
+        run: poetry run ruff check .
   poetry-test:
     strategy:
       fail-fast: false
@@ -93,36 +93,36 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
-    - name: Install Rust
-      run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-    - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@v2.7.3
-    - name: Install Poetry
-      run: pipx install poetry
-    - name: Configure poetry
-      run: |
-        poetry config virtualenvs.create true
-        poetry config virtualenvs.in-project true
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.11"
-    - name: Build package
-      run: cargo build --release
-    - name: Run creation
-      run: |
-        ./scripts/ci_run.sh ${{ matrix.project_type }} 1
-    - name: Install Dependencies
-      working-directory: ${{ env.WORKING_DIR }}
-      run: poetry install
-    - name: Pre-commit install
-      working-directory: ${{ env.WORKING_DIR }}
-      run: poetry run pre-commit install
-    - name: Test with pytest
-      working-directory: ${{ env.WORKING_DIR }}
-      run: poetry run pytest
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2.7.3
+      - name: Install Poetry
+        run: pipx install poetry
+      - name: Configure poetry
+        run: |
+          poetry config virtualenvs.create true
+          poetry config virtualenvs.in-project true
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Build package
+        run: cargo build --release
+      - name: Run creation
+        run: |
+          ./scripts/ci_run.sh ${{ matrix.project_type }} 1
+      - name: Install Dependencies
+        working-directory: ${{ env.WORKING_DIR }}
+        run: poetry install
+      - name: Pre-commit install
+        working-directory: ${{ env.WORKING_DIR }}
+        run: poetry run pre-commit install
+      - name: Test with pytest
+        working-directory: ${{ env.WORKING_DIR }}
+        run: poetry run pytest
   pyo3-linting:
     strategy:
       fail-fast: false
@@ -130,42 +130,42 @@ jobs:
         project_type: ["application", "lib"]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Install Just
-      uses: taiki-e/install-action@just
-    - name: Install Rust
-      run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-    - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@v2.7.3
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "${{ env.MIN_PYTHON_VERSION }}"
-    - name: Build package
-      run: cargo build --release
-    - name: Run creation
-      run: ./scripts/ci_run.sh ${{ matrix.project_type }} 2
-    - name: Install Dependencies
-      working-directory: ${{ env.WORKING_DIR }}
-      run: |
-        python -m pip install -U pip
-        python -m pip install -r requirements-dev.txt
-        python -m pip install -e .
-        maturin build --out dist
-        python -m pip install --no-index --find-links=dist/ my-project
-    - name: MyPy
-      working-directory: ${{ env.WORKING_DIR }}
-      run: just mypy
-    - name: Ruff
-      working-directory: ${{ env.WORKING_DIR }}
-      run: just ruff
-    - name: Generated Project Clippy
-      working-directory: ${{ env.WORKING_DIR }}
-      run: just clippy
-    - name: Generated Project Fmt
-      working-directory: ${{ env.WORKING_DIR }}
-      run: just fmt
+      - uses: actions/checkout@v4
+      - name: Install Just
+        uses: taiki-e/install-action@just
+      - name: Install Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2.7.3
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "${{ env.MIN_PYTHON_VERSION }}"
+      - name: Build package
+        run: cargo build --release
+      - name: Run creation
+        run: ./scripts/ci_run.sh ${{ matrix.project_type }} 2
+      - name: Install Dependencies
+        working-directory: ${{ env.WORKING_DIR }}
+        run: |
+          python -m pip install -U pip
+          python -m pip install -r requirements-dev.txt
+          python -m pip install -e .
+          maturin build --out dist
+          python -m pip install --no-index --find-links=dist/ my-project
+      - name: MyPy
+        working-directory: ${{ env.WORKING_DIR }}
+        run: just mypy
+      - name: Ruff
+        working-directory: ${{ env.WORKING_DIR }}
+        run: just ruff
+      - name: Generated Project Clippy
+        working-directory: ${{ env.WORKING_DIR }}
+        run: just clippy
+      - name: Generated Project Fmt
+        working-directory: ${{ env.WORKING_DIR }}
+        run: just fmt
   pyo3-python-test:
     strategy:
       fail-fast: false
@@ -174,34 +174,35 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
-    - name: Install Rust
-      run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-    - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@v2.7.3
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.11"
-    - name: Build package
-      run: cargo build --release
-    - name: Run creation
-      run: ./scripts/ci_run.sh ${{ matrix.project_type }} 2
-    - name: Install Dependencies
-      working-directory: ${{ env.WORKING_DIR }}
-      run: |
-        python -m pip install -U pip
-        python -m pip install -r requirements-dev.txt
-        python -m pip install -e .
-        maturin build --out dist
-        python -m pip install --no-index --find-links=dist/ my-project
-    - name: Pre-commit install
-      working-directory: ${{ env.WORKING_DIR }}
-      run: pre-commit install
-    - name: Test with pytest
-      working-directory: ${{ env.WORKING_DIR }}
-      run: pytest
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2.7.3
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Build package
+        run: cargo build --release
+      - name: Run creation
+        run: ./scripts/ci_run.sh ${{ matrix.project_type }} 2
+      - name: Install Dependencies
+        working-directory: ${{ env.WORKING_DIR }}
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U pre-commit
+          python -m pip install -r requirements-dev.txt
+          python -m pip install -e .
+          maturin build --out dist
+          python -m pip install --no-index --find-links=dist/ my-project
+      - name: Pre-commit install
+        working-directory: ${{ env.WORKING_DIR }}
+        run: pre-commit install
+      - name: Test with pytest
+        working-directory: ${{ env.WORKING_DIR }}
+        run: pytest
   setuptools-linting:
     strategy:
       fail-fast: false
@@ -209,32 +210,33 @@ jobs:
         project_type: ["application", "lib"]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Install Rust
-      run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-    - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@v2.7.3
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "${{ env.MIN_PYTHON_VERSION }}"
-    - name: Build package
-      run: cargo build --release
-    - name: Run creation
-      run: |
-        ./scripts/ci_run.sh ${{ matrix.project_type }} 3
-    - name: Install Dependencies
-      working-directory: ${{ env.WORKING_DIR }}
-      run: |
-        python -m pip install -U pip
-        python -m pip install -r requirements-dev.txt
-    - name: MyPy
-      working-directory: ${{ env.WORKING_DIR }}
-      run: mypy .
-    - name: ruff
-      working-directory: ${{ env.WORKING_DIR }}
-      run: ruff check .
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2.7.3
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "${{ env.MIN_PYTHON_VERSION }}"
+      - name: Build package
+        run: cargo build --release
+      - name: Run creation
+        run: |
+          ./scripts/ci_run.sh ${{ matrix.project_type }} 3
+      - name: Install Dependencies
+        working-directory: ${{ env.WORKING_DIR }}
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U pre-commit
+          python -m pip install -r requirements-dev.txt
+      - name: MyPy
+        working-directory: ${{ env.WORKING_DIR }}
+        run: mypy .
+      - name: ruff
+        working-directory: ${{ env.WORKING_DIR }}
+        run: ruff check .
   setuptools-test:
     strategy:
       fail-fast: false
@@ -243,29 +245,30 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
-    - name: Install Rust
-      run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-    - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@v2.7.3
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.11"
-    - name: Build package
-      run: cargo build --release
-    - name: Run creation
-      run: |
-        ./scripts/ci_run.sh ${{ matrix.project_type }} 3
-    - name: Install Dependencies
-      working-directory: ${{ env.WORKING_DIR }}
-      run: |
-        python -m pip install -U pip
-        python -m pip install -r requirements-dev.txt
-    - name: Pre-commit install
-      working-directory: ${{ env.WORKING_DIR }}
-      run: pre-commit install
-    - name: Test with pytest
-      working-directory: ${{ env.WORKING_DIR }}
-      run: pytest
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2.7.3
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Build package
+        run: cargo build --release
+      - name: Run creation
+        run: |
+          ./scripts/ci_run.sh ${{ matrix.project_type }} 3
+      - name: Install Dependencies
+        working-directory: ${{ env.WORKING_DIR }}
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U pre-commit
+          python -m pip install -r requirements-dev.txt
+      - name: Pre-commit install
+        working-directory: ${{ env.WORKING_DIR }}
+        run: pre-commit install
+      - name: Test with pytest
+        working-directory: ${{ env.WORKING_DIR }}
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ For package managment choose between:
 Dev packages:
 
 - [mypy](https://www.mypy-lang.org/) for static type checking
-- [pre-commit](https://github.com/pre-commit/pre-commit) for pre-commit hooks
 - [pytest](https://docs.pytest.org/en/latest/) for testing
 - [pytest-cov](https://github.com/pytest-dev/pytest-cov) for test coverage reports
 - [ruff](https://beta.ruff.rs/docs/) for linting and code formatting
@@ -25,7 +24,6 @@ Dev packages:
 
 - [maturin](https://github.com/PyO3/maturin) for package management
 - [mypy](https://www.mypy-lang.org/) for static type checking
-- [pre-commit](https://github.com/pre-commit/pre-commit) for pre-commit hooks
 - [pytest](https://docs.pytest.org/en/latest/) for testing
 - [pytest-cov](https://github.com/pytest-dev/pytest-cov) for test coverage reports
 - [ruff](https://beta.ruff.rs/docs/) for linting and code formatting

--- a/src/package_version.rs
+++ b/src/package_version.rs
@@ -7,7 +7,6 @@ use anyhow::Result;
 pub enum PythonPackage {
     Maturin,
     MyPy,
-    PreCommit,
     Pytest,
     PytestCov,
     Ruff,
@@ -19,7 +18,6 @@ impl fmt::Display for PythonPackage {
         match self {
             PythonPackage::Maturin => write!(f, "maturin"),
             PythonPackage::MyPy => write!(f, "mypy"),
-            PythonPackage::PreCommit => write!(f, "pre-commit"),
             PythonPackage::Pytest => write!(f, "pytest"),
             PythonPackage::PytestCov => write!(f, "pytest-cov"),
             PythonPackage::Ruff => write!(f, "ruff"),
@@ -114,8 +112,8 @@ impl LatestVersion for PythonPackageVersion {
 }
 
 impl PythonPackageVersion {
-    pub fn new(package: PythonPackage, min_python_version: &str) -> Self {
-        let version = default_version(&package, min_python_version);
+    pub fn new(package: PythonPackage) -> Self {
+        let version = default_version(&package);
 
         PythonPackageVersion { package, version }
     }
@@ -148,24 +146,10 @@ impl LatestVersion for RustPackageVersion {
     }
 }
 
-pub fn default_version(package: &PythonPackage, min_python_version: &str) -> String {
+pub fn default_version(package: &PythonPackage) -> String {
     match package {
         PythonPackage::Maturin => "1.4.0".to_string(),
         PythonPackage::MyPy => "1.8.0".to_string(),
-
-        // TODO: This isn't a good resolver but it will work for now. Should be imporoved.
-        PythonPackage::PreCommit => {
-            let version_info: Vec<&str> = min_python_version.split('.').collect();
-            if let Ok(minor) = version_info[1].parse::<i32>() {
-                if minor < 10 {
-                    "3.5.0".to_string()
-                } else {
-                    "3.6.2".to_string()
-                }
-            } else {
-                "3.6.2".to_string()
-            }
-        }
         PythonPackage::Pytest => "8.0.2".to_string(),
         PythonPackage::PytestCov => "4.1.0".to_string(),
         PythonPackage::Ruff => "0.3.0".to_string(),
@@ -186,24 +170,5 @@ pub fn pre_commit_repo(hook: &PreCommitHook) -> String {
         PreCommitHook::MyPy => "https://github.com/pre-commit/mirrors-mypy".to_string(),
         PreCommitHook::PreCommit => "https://github.com/pre-commit/pre-commit-hooks".to_string(),
         PreCommitHook::Ruff => "https://github.com/astral-sh/ruff-pre-commit".to_string(),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_less_than_three_ten() {
-        let version = default_version(&PythonPackage::PreCommit, "3.9");
-
-        assert_eq!("3.5.0", version)
-    }
-
-    #[test]
-    fn test_three_ten() {
-        let version = default_version(&PythonPackage::PreCommit, "3.10");
-
-        assert_eq!("3.6.2", version)
     }
 }

--- a/src/project_generator.rs
+++ b/src/project_generator.rs
@@ -269,26 +269,18 @@ fn build_latest_dev_dependencies(
     is_application: bool,
     download_latest_packages: bool,
     project_manager: &ProjectManager,
-    min_python_version: &str,
 ) -> String {
     let mut version_string = String::new();
     let mut packages = vec![
-        PythonPackageVersion::new(PythonPackage::MyPy, min_python_version),
-        PythonPackageVersion::new(PythonPackage::PreCommit, min_python_version),
-        PythonPackageVersion::new(PythonPackage::Pytest, min_python_version),
-        PythonPackageVersion::new(PythonPackage::PytestCov, min_python_version),
-        PythonPackageVersion::new(PythonPackage::Ruff, min_python_version),
+        PythonPackageVersion::new(PythonPackage::MyPy),
+        PythonPackageVersion::new(PythonPackage::Pytest),
+        PythonPackageVersion::new(PythonPackage::PytestCov),
+        PythonPackageVersion::new(PythonPackage::Ruff),
     ];
 
     match project_manager {
-        ProjectManager::Maturin => packages.push(PythonPackageVersion::new(
-            PythonPackage::Maturin,
-            min_python_version,
-        )),
-        ProjectManager::Poetry => packages.push(PythonPackageVersion::new(
-            PythonPackage::Tomli,
-            min_python_version,
-        )),
+        ProjectManager::Maturin => packages.push(PythonPackageVersion::new(PythonPackage::Maturin)),
+        ProjectManager::Poetry => packages.push(PythonPackageVersion::new(PythonPackage::Tomli)),
         ProjectManager::Setuptools => (),
     };
 
@@ -466,7 +458,7 @@ ignore=[
         creator_email => project_info.creator_email,
         license => license_text,
         min_python_version => project_info.min_python_version,
-        dev_dependencies => build_latest_dev_dependencies(project_info.is_application, project_info.download_latest_packages, &project_info.project_manager, &project_info.min_python_version),
+        dev_dependencies => build_latest_dev_dependencies(project_info.is_application, project_info.download_latest_packages, &project_info.project_manager),
         max_line_length => project_info.max_line_length,
         module => module,
         is_application => project_info.is_application,
@@ -489,7 +481,6 @@ fn save_dev_requirements(project_info: &ProjectInfo) -> Result<()> {
         project_info.is_application,
         project_info.download_latest_packages,
         &project_info.project_manager,
-        &project_info.min_python_version,
     );
 
     save_file_with_content(&file_path, &content)?;
@@ -689,17 +680,15 @@ mod tests {
         }
     }
 
-    fn pinned_poetry_dependencies(min_python_version: &str) -> String {
-        let mypy = default_version(&PythonPackage::MyPy, min_python_version);
-        let pre_commit = default_version(&PythonPackage::PreCommit, min_python_version);
-        let pytest = default_version(&PythonPackage::Pytest, min_python_version);
-        let pytest_cov = default_version(&PythonPackage::PytestCov, min_python_version);
-        let ruff = default_version(&PythonPackage::Ruff, min_python_version);
-        let tomli = default_version(&PythonPackage::Tomli, min_python_version);
+    fn pinned_poetry_dependencies() -> String {
+        let mypy = default_version(&PythonPackage::MyPy);
+        let pytest = default_version(&PythonPackage::Pytest);
+        let pytest_cov = default_version(&PythonPackage::PytestCov);
+        let ruff = default_version(&PythonPackage::Ruff);
+        let tomli = default_version(&PythonPackage::Tomli);
         format!(
             r#"[tool.poetry.group.dev.dependencies]
 mypy = "{mypy}"
-pre-commit = "{pre_commit}"
 pytest = "{pytest}"
 pytest-cov = "{pytest_cov}"
 ruff = "{ruff}"
@@ -707,17 +696,15 @@ tomli = {{version = "{tomli}", python = "<3.11"}}"#
         )
     }
 
-    fn min_poetry_dependencies(min_python_version: &str) -> String {
-        let mypy = default_version(&PythonPackage::MyPy, min_python_version);
-        let pre_commit = default_version(&PythonPackage::PreCommit, min_python_version);
-        let pytest = default_version(&PythonPackage::Pytest, min_python_version);
-        let pytest_cov = default_version(&PythonPackage::PytestCov, min_python_version);
-        let ruff = default_version(&PythonPackage::Ruff, min_python_version);
-        let tomli = default_version(&PythonPackage::Tomli, min_python_version);
+    fn min_poetry_dependencies() -> String {
+        let mypy = default_version(&PythonPackage::MyPy);
+        let pytest = default_version(&PythonPackage::Pytest);
+        let pytest_cov = default_version(&PythonPackage::PytestCov);
+        let ruff = default_version(&PythonPackage::Ruff);
+        let tomli = default_version(&PythonPackage::Tomli);
         format!(
             r#"[tool.poetry.group.dev.dependencies]
 mypy = ">={mypy}"
-pre-commit = ">={pre_commit}"
 pytest = ">={pytest}"
 pytest-cov = ">={pytest_cov}"
 ruff = ">={ruff}"
@@ -725,16 +712,14 @@ tomli = {{version = ">={tomli}", python = "<3.11"}}"#
         )
     }
 
-    fn pinned_requirments_file(min_python_version: &str) -> String {
-        let mypy = default_version(&PythonPackage::MyPy, min_python_version);
-        let pre_commit = default_version(&PythonPackage::PreCommit, min_python_version);
-        let pytest = default_version(&PythonPackage::Pytest, min_python_version);
-        let pytest_cov = default_version(&PythonPackage::PytestCov, min_python_version);
-        let ruff = default_version(&PythonPackage::Ruff, min_python_version);
-        let maturin = default_version(&PythonPackage::Maturin, min_python_version);
+    fn pinned_requirments_file() -> String {
+        let mypy = default_version(&PythonPackage::MyPy);
+        let pytest = default_version(&PythonPackage::Pytest);
+        let pytest_cov = default_version(&PythonPackage::PytestCov);
+        let ruff = default_version(&PythonPackage::Ruff);
+        let maturin = default_version(&PythonPackage::Maturin);
         format!(
             r#"mypy=={mypy}
-pre-commit=={pre_commit}
 pytest=={pytest}
 pytest-cov=={pytest_cov}
 ruff=={ruff}
@@ -744,16 +729,14 @@ maturin=={maturin}
         )
     }
 
-    fn min_requirments_file(min_python_version: &str) -> String {
-        let mypy = default_version(&PythonPackage::MyPy, min_python_version);
-        let maturin = default_version(&PythonPackage::Maturin, min_python_version);
-        let pre_commit = default_version(&PythonPackage::PreCommit, min_python_version);
-        let pytest = default_version(&PythonPackage::Pytest, min_python_version);
-        let pytest_cov = default_version(&PythonPackage::PytestCov, min_python_version);
-        let ruff = default_version(&PythonPackage::Ruff, min_python_version);
+    fn min_requirments_file() -> String {
+        let mypy = default_version(&PythonPackage::MyPy);
+        let maturin = default_version(&PythonPackage::Maturin);
+        let pytest = default_version(&PythonPackage::Pytest);
+        let pytest_cov = default_version(&PythonPackage::PytestCov);
+        let ruff = default_version(&PythonPackage::Ruff);
         format!(
             r#"mypy>={mypy}
-pre-commit>={pre_commit}
 pytest>={pytest}
 pytest-cov>={pytest_cov}
 ruff>={ruff}
@@ -1200,7 +1183,7 @@ ignore=[
             project_info.creator,
             project_info.creator_email,
             project_info.min_python_version,
-            pinned_poetry_dependencies(&project_info.min_python_version),
+            pinned_poetry_dependencies(),
             project_info.source_dir,
             project_info.max_line_length,
             pyupgrade_version,
@@ -1290,7 +1273,7 @@ ignore=[
             project_info.creator,
             project_info.creator_email,
             project_info.min_python_version,
-            pinned_poetry_dependencies(&project_info.min_python_version),
+            pinned_poetry_dependencies(),
             project_info.source_dir,
             project_info.max_line_length,
             pyupgrade_version,
@@ -1379,7 +1362,7 @@ ignore=[
             project_info.creator,
             project_info.creator_email,
             project_info.min_python_version,
-            pinned_poetry_dependencies(&project_info.min_python_version),
+            pinned_poetry_dependencies(),
             project_info.source_dir,
             project_info.max_line_length,
             pyupgrade_version,
@@ -1469,7 +1452,7 @@ ignore=[
             project_info.creator,
             project_info.creator_email,
             project_info.min_python_version,
-            min_poetry_dependencies(&project_info.min_python_version),
+            min_poetry_dependencies(),
             project_info.source_dir,
             project_info.max_line_length,
             pyupgrade_version,
@@ -2152,10 +2135,7 @@ ignore=[
 
         let content = std::fs::read_to_string(expected_file).unwrap();
 
-        assert_eq!(
-            content,
-            pinned_requirments_file(&project_info.min_python_version)
-        );
+        assert_eq!(content, pinned_requirments_file());
     }
 
     #[test]
@@ -2172,10 +2152,7 @@ ignore=[
 
         let content = std::fs::read_to_string(expected_file).unwrap();
 
-        assert_eq!(
-            content,
-            min_requirments_file(&project_info.min_python_version)
-        );
+        assert_eq!(content, min_requirments_file());
     }
 
     #[test]
@@ -2192,10 +2169,7 @@ ignore=[
 
         let content = std::fs::read_to_string(expected_file).unwrap();
 
-        assert_eq!(
-            content,
-            pinned_requirments_file(&project_info.min_python_version)
-        );
+        assert_eq!(content, pinned_requirments_file());
     }
 
     #[test]
@@ -2212,10 +2186,7 @@ ignore=[
 
         let content = std::fs::read_to_string(expected_file).unwrap();
 
-        assert_eq!(
-            content,
-            min_requirments_file(&project_info.min_python_version)
-        );
+        assert_eq!(content, min_requirments_file());
     }
 
     #[test]


### PR DESCRIPTION
There are issues with installing newer versions on pre-commit on older versions of python (out of pre-commits control). This can lead to install errors with certain combinations of pre-commit and Python  so I am removing it as a dev dependency. It can instead be used as a globally installed package.