### PR TITLE
Bump default mkdocs-material and mkdocstrings

### DIFF
--- a/src/package_version.rs
+++ b/src/package_version.rs
@@ -189,8 +189,8 @@ pub fn default_version(package: &PythonPackage) -> String {
     match package {
         PythonPackage::Maturin => "1.7.4".to_string(),
         PythonPackage::Mkdocs => "1.6.1".to_string(),
-        PythonPackage::MkdocsMaterial => "9.5.39".to_string(),
-        PythonPackage::Mkdocstrings => "0.26.1".to_string(),
+        PythonPackage::MkdocsMaterial => "9.5.40".to_string(),
+        PythonPackage::Mkdocstrings => "0.26.2".to_string(),
         PythonPackage::MyPy => "1.11.2".to_string(),
         PythonPackage::PreCommit => "4.0.0".to_string(),
         PythonPackage::Pytest => "8.3.3".to_string(),


### PR DESCRIPTION
mkdocs-material 9.5.39 -> 9.5.40
mkdocstrings 0.26.1 -> 0.26.2