### PR TITLE
Fastapi template windows

### DIFF
--- a/src/fastapi/fastapi_installer.rs
+++ b/src/fastapi/fastapi_installer.rs
@@ -15,10 +15,9 @@ const FASTAPI_BASE_DEPENDENCIES: &[&str] = &[
     "pydantic-settings",
     "pyjwt",
     "python-multipart",
+    "uvloop; sys_platform != 'win32'",
     "valkey",
 ];
-
-const FASTAPI_BASE_UNIX_DEPENDENCIES: &[&str] = &["uvloop"];
 
 const FASTAPI_BASE_DEV_DEPENDENCIES: &[&str] = &["httpx", "pytest-xdist"];
 
@@ -34,16 +33,8 @@ pub fn install_fastapi_dependencies(project_info: &ProjectInfo) -> Result<()> {
     Ok(())
 }
 
-fn get_fastapi_base_dependencies() -> Vec<&'static str> {
-    let mut base_dependencies = FASTAPI_BASE_DEPENDENCIES.to_vec();
-    if cfg!(unix) {
-        base_dependencies.extend_from_slice(FASTAPI_BASE_UNIX_DEPENDENCIES);
-    }
-    base_dependencies
-}
-
 fn uv_fastapi_depencency_installer(project_info: &ProjectInfo) -> Result<()> {
-    let mut dependencies = get_fastapi_base_dependencies();
+    let mut dependencies = FASTAPI_BASE_DEPENDENCIES.to_vec();
     if project_info.database_manager == Some(DatabaseManager::SqlAlchemy) {
         dependencies.push("sqlalchemy");
         dependencies.push("alembic");
@@ -77,7 +68,7 @@ fn uv_fastapi_depencency_installer(project_info: &ProjectInfo) -> Result<()> {
 }
 
 fn poetry_fastapi_depencency_installer(project_info: &ProjectInfo) -> Result<()> {
-    let mut dependencies = get_fastapi_base_dependencies();
+    let mut dependencies = FASTAPI_BASE_DEPENDENCIES.to_vec();
     if project_info.database_manager == Some(DatabaseManager::SqlAlchemy) {
         dependencies.push("sqlalchemy");
         dependencies.push("alembic");
@@ -121,7 +112,7 @@ fn setuptools_fastapi_depencency_installer(project_info: &ProjectInfo) -> Result
         bail!("Failed to create virtual environment: {stderr}");
     }
 
-    let mut dependencies = get_fastapi_base_dependencies();
+    let mut dependencies = FASTAPI_BASE_DEPENDENCIES.to_vec();
     let dev_dependencies = FASTAPI_BASE_DEV_DEPENDENCIES.to_vec();
     if project_info.database_manager == Some(DatabaseManager::SqlAlchemy) {
         dependencies.push("sqlalchemy");

--- a/src/fastapi/fastapi_installer.rs
+++ b/src/fastapi/fastapi_installer.rs
@@ -20,7 +20,7 @@ const FASTAPI_BASE_DEPENDENCIES: &[&str] = &[
 
 const FASTAPI_BASE_UNIX_DEPENDENCIES: &[&str] = &["uvloop"];
 
-const FASTAPI_BASE_DEV_DEPENDENCIES: &[&str] = &["httpx"];
+const FASTAPI_BASE_DEV_DEPENDENCIES: &[&str] = &["httpx", "pytest-xdist"];
 
 pub fn install_fastapi_dependencies(project_info: &ProjectInfo) -> Result<()> {
     match project_info.project_manager {


### PR DESCRIPTION
Because `uvloop` is only supported on unix systems, I added a OS check so that it's only added as a dependency if we're generating the project on a unix machine.

Another option could be to make the dependency:

"uvloop; sys_platform != 'win32'"

which would then only get installed by the package manager if we're on windows. The upside here is we don't have to manage which OS we're running on for project generation, the downside being that it would be added to all project configs, including those that may only be windows-based.

I'm open to suggestions on which method is preferred, and I can make any updates.
